### PR TITLE
Bug: always return Dictionnairy instead of list

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -2,8 +2,26 @@
 # pylint: disable=missing-docstring
 
 from flask import Flask
+from flask import jsonify
 app = Flask(__name__)
+
+PRODUCTS = {
+    1: { 'id': 1, 'name': 'Skello' },
+    2: { 'id': 2, 'name': 'Socialive.tv' },
+    3: { 'id': 3, 'name': 'Crunchyroll.tv' },
+}
+
+API_URL = '/api/v1/'
 
 @app.route('/')
 def hello():
     return "Hello World!"
+
+@app.route(f"{API_URL}products")
+def products_action():
+    res = []
+
+    for p in PRODUCTS.items():
+        res.append(p[1])
+    
+    return jsonify(PRODUCTS)


### PR DESCRIPTION
When I call _api/v1/products_ it returns a dictionnary of products instead a list of products